### PR TITLE
Delay delete

### DIFF
--- a/delete.sh
+++ b/delete.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Sleep for one minute to ensure a backup is made first.
+sleep 1m
+
 # Go to the backups directory.
 cd /backups
 


### PR DESCRIPTION
- Delete script now has an initial one minute delay, to ensure a backup is created first.
  - Also to prevent this:
    ![image](https://user-images.githubusercontent.com/68612932/126045649-e737136f-80b0-4727-80fc-c7872812997c.png)
